### PR TITLE
feat: Possibilita aplicação rodar localmente e com docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ WORKDIR /app
 COPY --from=build /app/food-main/target/*.jar ./app.jar
 
 # Executa a aplicacao
-CMD ["java", "-jar", "app.jar"]
+CMD ["java", "-jar", "app.jar", "--spring.profiles.active=prod"]

--- a/config/env/.env.dev
+++ b/config/env/.env.dev
@@ -1,0 +1,10 @@
+# MySQL config
+MYSQL_ROOT_PASSWORD: root
+MYSQL_DATABASE: pedidos
+MYSQL_USER: pedidos
+MYSQL_PASSWORD: pedidos
+
+# Spring database config
+SPRING_DATASOURCE_URL: jdbc:mysql://localhost:3306/pedidos
+SPRING_DATASOURCE_USERNAME: pedidos
+SPRING_DATASOURCE_PASSWORD: pedidos

--- a/config/env/.env.prod
+++ b/config/env/.env.prod
@@ -1,0 +1,10 @@
+# MySQL config
+MYSQL_ROOT_PASSWORD: root
+MYSQL_DATABASE: pedidos
+MYSQL_USER: pedidos
+MYSQL_PASSWORD: pedidos
+
+# Spring database config
+SPRING_DATASOURCE_URL: jdbc:mysql://mysqldb:3306/pedidos
+SPRING_DATASOURCE_USERNAME: pedidos
+SPRING_DATASOURCE_PASSWORD: pedidos

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,17 +13,14 @@ services:
     networks:
       - foodapi-network
     restart: always
-    environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: pedidos
-      MYSQL_USER: pedidos
-      MYSQL_PASSWORD: pedidos
+    env_file:
+      - ./config/env/.env.prod
   springboot-app:
     image: springboot-app
     networks:
       - foodapi-network
-    environment:
-      DATASOURCE_URL: jdbc:mysql://mysqldb:3306/pedidos
+    env_file:
+      - ./config/env/.env.prod
     build: .
     depends_on:
       - mysqldb

--- a/food-database/src/main/resources/application.prod.properties
+++ b/food-database/src/main/resources/application.prod.properties
@@ -1,0 +1,7 @@
+# Config do banco de dados MySQL
+spring.datasource.url=${SPRING_DATASOURCE_URL}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+
+# Server
+server.port=8080

--- a/food-database/src/main/resources/application.properties
+++ b/food-database/src/main/resources/application.properties
@@ -1,12 +1,8 @@
-
-
 # Config do banco de dados MySQL
-#spring.datasource.url=${DATASOURCE_URL}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://localhost:3306/pedidos
 spring.datasource.username=pedidos
 spring.datasource.password=pedidos
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-
 
 # Config FlYWAY
 spring.flyway.enabled=true
@@ -14,3 +10,6 @@ spring.flyway.url=${spring.datasource.url}
 spring.flyway.user=${spring.datasource.username}
 spring.flyway.password=${spring.datasource.password}
 spring.flyway.locations=db
+
+# Server
+server.port=8081


### PR DESCRIPTION
# Ticket

https://www.notion.so/Possibilita-docker-e-localhost-conviverem-juntos-bc7513dcd0624e8db142de74dea31fcb?pvs=4

## Descrição

- Remove variáveis do arquivo `Dockerfile` e transfere para os arquivos de variáveis `.env.dev` e `.env.prod`;
- Possibilita que a aplicação suba ao mesmo tempo tanto `localmente` quanto pelo `docker`;
  - Altera as portas para aplicação local rodar em `8081` e produção como `8080`;
- Cria arquivo adicional de `applicaiton.prod.properties` para  possibilitar a execução através de `profiles`;

## Dicas

**Para rodar a aplicação no modo produção**:

```bash
docker compose up
```

**Para rodar a aplicação no modo dev**:

1. Rode o banco de dados:

```bash
docker compose up mysqldb
```

2. Rode a aplicação através de sua IDE ou via linha de comando.
